### PR TITLE
Update CMake logic to export devel/install more cleanly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,18 +28,17 @@ ExternalProject_Add_Step(pybind11
 if(IS_DIRECTORY ${CMAKE_INSTALL_PREFIX})
   message(WARNING "Compiling for install workspace (${CMAKE_INSTALL_PREFIX})")
   catkin_package(
-    # INCLUDE_DIRS include/pybind11_catkin
+    INCLUDE_DIRS include
     LIBRARIES ${PYTHON_LIBRARIES}
-    CATKIN_DEPENDS
-    CFG_EXTRAS pybind.cmake
+    CFG_EXTRAS pybind11_catkin.cmake
   )
 else()
   message(WARNING "Compiling for devel workspace")
   file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})
   catkin_package(
-    INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME} ${EIGEN3_INCLUDE_DIR}
+    INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include ${EIGEN3_INCLUDE_DIR}
     LIBRARIES ${PYTHON_LIBRARIES}
-    CFG_EXTRAS pybind.cmake
+    CFG_EXTRAS pybind11_catkin.cmake
   )
 endif()
 

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -15,11 +15,10 @@ set(PYTHON_LIBRARIES ${PYTHON_LIBRARIES} CACHE INTERNAL "")
 
 set(PYTHON_EXECUTABLE ${TEMP_PYTHON_EXECUTABLE} CACHE INTERNAL "")
 
-# Workaround for install workspaces
-include_directories(${pybind11_catkin_INCLUDE_DIRS}/pybind11_catkin)
-
-# Workaround for devel workspaces
-include_directories(${CMAKE_CURRENT_LIST_DIR}/../../../include/pybind11_catkin)
+# This sets the include dirs to be transient, i.e., end-users do not need to
+# explicitly specify pybind11_catkin without polluting the include directories
+# (avoids conflicts).
+set(pybind11_catkin_INCLUDE_DIRS "${pybind11_catkin_INCLUDE_DIRS}/pybind11_catkin")
 
 macro(pybind_add_module target_name other)
     pybind11_add_module(${ARGV})
@@ -31,6 +30,5 @@ macro(pybind_add_module target_name other)
       COMMAND ${CMAKE_COMMAND} -E make_directory ${PYTHON_LIB_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${target_name}> ${PYTHON_LIB_DIR}/${target_name}.so
       WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}
-  COMMENT "Copying library files to python directory" )
-
+  COMMENT "Copying library files to python directory")
 endmacro(pybind_add_module)


### PR DESCRIPTION
Updated and checked to make sure we aren't conflicting (ready for a full audit).

Installing in a clean install workspace leaves the following:

```
install/share/pybind11_catkin/package.xml
install/share/pybind11_catkin/cmake/pybind11Tools.cmake
install/share/pybind11_catkin/cmake/pybind11_catkinConfig-version.cmake
install/share/pybind11_catkin/cmake/pybind11_catkinConfig.cmake
install/share/pybind11_catkin/cmake/pybind11_catkin.cmake
install/share/pybind11_catkin/cmake/FindPythonLibsNew.cmake
install/share/catkin_tools_prebuild/package.xml
install/share/catkin_tools_prebuild/cmake/catkin_tools_prebuildConfig-version.cmake
install/share/catkin_tools_prebuild/cmake/catkin_tools_prebuildConfig.cmake
install/setup.zsh
install/_setup_util.py
install/setup.sh
install/setup.bash
install/lib/pkgconfig/pybind11_catkin.pc
install/lib/pkgconfig/catkin_tools_prebuild.pc
install/include/pybind11_catkin/pybind11/stl.h
install/include/pybind11_catkin/pybind11/stl_bind.h
install/include/pybind11_catkin/pybind11/pytypes.h
install/include/pybind11_catkin/pybind11/pybind11.h
install/include/pybind11_catkin/pybind11/options.h
install/include/pybind11_catkin/pybind11/operators.h
install/include/pybind11_catkin/pybind11/numpy.h
install/include/pybind11_catkin/pybind11/iostream.h
install/include/pybind11_catkin/pybind11/functional.h
install/include/pybind11_catkin/pybind11/eval.h
install/include/pybind11_catkin/pybind11/embed.h
install/include/pybind11_catkin/pybind11/eigen.h
install/include/pybind11_catkin/pybind11/detail/typeid.h
install/include/pybind11_catkin/pybind11/detail/internals.h
install/include/pybind11_catkin/pybind11/detail/init.h
install/include/pybind11_catkin/pybind11/detail/descr.h
install/include/pybind11_catkin/pybind11/detail/common.h
install/include/pybind11_catkin/pybind11/detail/class.h
install/include/pybind11_catkin/pybind11/complex.h
install/include/pybind11_catkin/pybind11/common.h
install/include/pybind11_catkin/pybind11/chrono.h
install/include/pybind11_catkin/pybind11/cast.h
install/include/pybind11_catkin/pybind11/buffer_info.h
install/include/pybind11_catkin/pybind11/attr.h
install/etc/catkin/profile.d/06-ctr-nuke.sh
install/env.sh
```