### PR TITLE
Cleanup cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,20 +18,11 @@ ExternalProject_Add_Step(pybind11_src CopyToDevel
   DEPENDEES install
 )
 
-if(IS_DIRECTORY ${CMAKE_INSTALL_PREFIX})
-  message(WARNING "Compiling for install workspace (${CMAKE_INSTALL_PREFIX})")
-  catkin_package(
-    INCLUDE_DIRS include/${PROJECT_NAME}
-    CFG_EXTRAS pybind11_catkin.cmake
-  )
-else()
-  message(WARNING "Compiling for devel workspace")
-  file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})
-  catkin_package(
-    INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include
-    CFG_EXTRAS pybind11_catkin.cmake
-  )
-endif()
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})
+catkin_package(
+  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}
+  CFG_EXTRAS pybind11_catkin.cmake
+)
 
 install(
   DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ install(
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 install(
-  FILES ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/FindPythonLibsNew.cmake ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/FindPythonLibsNew.cmake ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/pybind11Tools.cmake
+  FILES
+    ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/FindPythonLibsNew.cmake
+    ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/pybind11Tools.cmake
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ include(ExternalProject)
 ExternalProject_Add(pybind11_src
   URL "https://github.com/pybind/pybind11/archive/v2.4.3.zip"
   UPDATE_COMMAND ""
-  CMAKE_ARGS -DPYBIND11_TEST:BOOL=OFF -DPYBIND11_INSTALL:BOOL=ON -DCMAKE_INSTALL_PREFIX:PATH=${PROJECT_BINARY_DIR}/install
+  CMAKE_ARGS -DPYBIND11_PYTHON_VERSION=${PYTHON_VERSION_STRING}
+             -DPYBIND11_TEST:BOOL=OFF -DPYBIND11_INSTALL:BOOL=ON
+             -DCMAKE_INSTALL_PREFIX:PATH=${PROJECT_BINARY_DIR}/install
 )
 ExternalProject_Add_Step(pybind11_src CopyToDevel
   COMMENT "Copying to devel"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,15 +22,13 @@ if(IS_DIRECTORY ${CMAKE_INSTALL_PREFIX})
   message(WARNING "Compiling for install workspace (${CMAKE_INSTALL_PREFIX})")
   catkin_package(
     INCLUDE_DIRS include/${PROJECT_NAME}
-    LIBRARIES ${PYTHON_LIBRARIES}
     CFG_EXTRAS pybind11_catkin.cmake
   )
 else()
   message(WARNING "Compiling for devel workspace")
   file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})
   catkin_package(
-    INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include ${EIGEN3_INCLUDE_DIR}
-    LIBRARIES ${PYTHON_LIBRARIES}
+    INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include
     CFG_EXTRAS pybind11_catkin.cmake
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,7 @@ find_package(catkin REQUIRED)
 include(ExternalProject)
 
 ExternalProject_Add(pybind11_src
-  URL "https://github.com/pybind/pybind11/archive/v2.2.4.zip"
-  URL_MD5 "06f0bbf25dc9c4fe15092e9e03a8fc01"
+  URL "https://github.com/pybind/pybind11/archive/v2.4.3.zip"
   UPDATE_COMMAND ""
   CMAKE_ARGS -DPYBIND11_TEST:BOOL=OFF -DPYBIND11_INSTALL:BOOL=ON -DCMAKE_INSTALL_PREFIX:PATH=${PROJECT_BINARY_DIR}/install
 )

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -16,15 +16,7 @@ set(PYTHON_LIBRARIES ${PYTHON_LIBRARIES} CACHE INTERNAL "")
 set(PYTHON_EXECUTABLE ${TEMP_PYTHON_EXECUTABLE} CACHE INTERNAL "")
 
 macro(pybind_add_module target_name other)
-    include_directories(${pybind11_catkin_INCLUDE_DIRS}/pybind11_catkin) # Such that libraries are locally available as pybind11/pybind11, without exporting.
     pybind11_add_module(${ARGV})
     target_link_libraries(${target_name} PRIVATE ${PYTHON_LIBRARIES} ${catkin_LIBRARIES})
-    set_target_properties(${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_GLOBAL_PYTHON_DESTINATION})
-    set(PYTHON_LIB_DIR ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION})
-    add_custom_command(TARGET ${target_name}
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${PYTHON_LIB_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${target_name}> ${PYTHON_LIB_DIR}/${target_name}.so
-      WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}
-  COMMENT "Copying library files to python directory")
+    set_target_properties(${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION})
 endmacro(pybind_add_module)

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -1,19 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 
+# Configure pybind11 using the cmake file provided by the upstream package.
+# This finds python includes and libs and defines pybind11_add_module()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-
-set(TEMP_PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE})
-if(DEFINED PYBIND_PYTHON_EXECUTABLE)
-    set(PYTHON_EXECUTABLE ${PYBIND_PYTHON_EXECUTABLE} CACHE INTERNAL "")
-endif()
-
 include(pybind11Tools)
 
-# Cache variables so pybind11_add_module can be used in parent projects
-set(PYBIND11_INCLUDE_DIR ${PYBIND11_INCLUDE_DIR} CACHE INTERNAL "")
-set(PYTHON_LIBRARIES ${PYTHON_LIBRARIES} CACHE INTERNAL "")
-
-set(PYTHON_EXECUTABLE ${TEMP_PYTHON_EXECUTABLE} CACHE INTERNAL "")
+# set variables used by pybind11_add_module()
+set(PYBIND11_INCLUDE_DIR ${pybind11_catkin_INCLUDE_DIRS})
+list(APPEND pybind11_catkin_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
 
 macro(pybind_add_module target_name other)
     pybind11_add_module(${ARGV})

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 # Configure pybind11 using the cmake file provided by the upstream package.
 # This finds python includes and libs and defines pybind11_add_module()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
 include(pybind11Tools)
 
 # set variables used by pybind11_add_module()

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -7,8 +7,11 @@ set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
 include(pybind11Tools)
 
 # set variables used by pybind11_add_module()
-set(PYBIND11_INCLUDE_DIR ${pybind11_catkin_INCLUDE_DIRS})
-list(APPEND pybind11_catkin_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
+if(@INSTALLSPACE@)
+  set(pybind11_catkin_INCLUDE_DIRS "${pybind11_catkin_INCLUDE_DIRS}/@PROJECT_NAME@")
+endif()
+set(PYBIND11_INCLUDE_DIR "${pybind11_catkin_INCLUDE_DIRS}")
+list(APPEND pybind11_catkin_INCLUDE_DIRS "${PYTHON_INCLUDE_DIRS}")
 
 macro(pybind_add_module target_name other)
     pybind11_add_module(${ARGV})

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pybind11_catkin</name>
-  <version>2.2.4</version>
+  <version>2.4.3</version>
   <description>The pybind11 package</description>
   <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>
   <maintainer email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -8,10 +8,8 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <!-- <build_depend>git</build_depend> -->
-  <depend>python</depend>
-  <depend>python-numpy</depend>
-  <depend>rospy</depend>
-  <depend>eigen</depend>
 
+  <build_export_depend>python</build_export_depend>
+  <build_export_depend>python-numpy</build_export_depend>
+  <build_export_depend>eigen</build_export_depend>
 </package>


### PR DESCRIPTION
This addresses #10 and several other minor issues in the cmake files. See individual commits and their commit messages for details.
One open question is whether Eigen and numpy should be really package dependencies [here](https://github.com/ipab-slmc/pybind11_catkin/pull/11/commits/ff0de68290a1c22d1d154ea056ef6db0b536f392#diff-34ae68f4adad56c25c5bc05dcb64794eR13-R14)?
These are only required if you actually want to use those features in your downstream project.
Hence, I would argue, the downstream project is responsible for including them.