### PR TITLE
Update to 2.9.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED)
 include(ExternalProject)
 
 ExternalProject_Add(pybind11_src
-  URL "https://github.com/pybind/pybind11/archive/v2.6.1.zip"
+  URL "https://github.com/pybind/pybind11/archive/refs/tags/v2.9.2.zip"
   UPDATE_COMMAND ""
   CMAKE_ARGS -DPYBIND11_NOPYTHON=TRUE
              -DPYBIND11_TEST=OFF

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>pybind11_catkin</name>
-  <version>2.6.1</version>
+  <version>2.9.2</version>
   <description>The pybind11 package</description>
   <maintainer email="wolfgang@robots.ox.ac.uk">Wolfgang Merkt</maintainer>
   <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>


### PR DESCRIPTION
That's the latest pybind11 version.

I tried this locally to make [cvnp](https://github.com/pthom/cvnp) work (a nice library to support conversion between numpy and opencv), but I guess we need to test with other packages to check everything looks fine.

