### PR TITLE
Ignore DESTDIR for the internal ExternalProject_Add() command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ ExternalProject_Add(pybind11_src
              -DPYBIND11_INSTALL=ON
              -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/install
              -DCMAKE_INSTALL_INCLUDEDIR=${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}
+  # Workaround if DESTDIR is set
+  # See https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
+  INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR= install
 )
 # We need to copy the entire content of the cmake/pybind11 folder to the correct place but with a different structure:
 ExternalProject_Add_Step(pybind11_src CopyToDevel


### PR DESCRIPTION
... using the solution suggested in https://gitlab.kitware.com/cmake/cmake/-/issues/18165.

This works for me. Without having read the complete thread, this approach likely also fixes https://github.com/ipab-slmc/pybind11_catkin/issues/16.