### PR TITLE
Improve CI + Fix broken install

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [melodic, noetic]
+        distro: [noetic]
     env:
       ROS_DISTRO: ${{ matrix.distro }}
       DOWNSTREAM_WORKSPACE: github:arturmiller/pybind11_examples#master
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [melodic, noetic]
+        distro: [noetic]
     env:
       ROS_DISTRO: ${{ matrix.distro }}
       PRERELEASE: true

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -2,16 +2,31 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  CI:
+  ci:
     strategy:
+      fail-fast: false
       matrix:
-        env:
-          - {ROS_DISTRO: melodic}
-          - {ROS_DISTRO: noetic}
+        distro: [melodic, noetic]
     env:
-      PRERELEASE: true
+      ROS_DISTRO: ${{ matrix.distro }}
+      DOWNSTREAM_WORKSPACE: github:arturmiller/pybind11_examples#master
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: 'ros-industrial/industrial_ci@6a8f546cbd31fbd5c9f77e3409265c8b39abc3d6'
-        env: ${{ matrix.env }}
+      - uses: ros-industrial/industrial_ci@master
+
+  prerelease:
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [melodic, noetic]
+    env:
+      ROS_DISTRO: ${{ matrix.distro }}
+      PRERELEASE: true
+      DOWNSTREAM_WORKSPACE: github:arturmiller/pybind11_examples#master
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ros-industrial/industrial_ci@master

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -7,9 +7,11 @@ jobs:
       fail-fast: false
       matrix:
         distro: [noetic]
+        builder: [catkin_tools, catkin_make_isolated_devel]
     env:
       ROS_DISTRO: ${{ matrix.distro }}
       DOWNSTREAM_WORKSPACE: github:arturmiller/pybind11_examples#master
+      BEFORE_SETUP_DOWNSTREAM_WORKSPACE: ${{ matrix.builder != 'catkin_make_isolated_devel' && 'rm -rf $HOME/target_ws/devel' || '' }}
 
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,16 @@ ExternalProject_Add(pybind11_src
              -DPYBIND11_TEST=OFF
              -DPYBIND11_INSTALL=ON
              -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/install
-             -DCMAKE_INSTALL_INCLUDEDIR=${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}
   # Workaround if DESTDIR is set
   # See https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
   INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR= install
 )
-# We need to copy the entire content of the cmake/pybind11 folder to the correct place but with a different structure:
+
+# Copy cmake/pybind11 and include/pybind11 to corresponding devel space folders
 ExternalProject_Add_Step(pybind11_src CopyToDevel
   COMMENT "Copying to devel"
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/share/cmake/pybind11/ ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/share/cmake/pybind11 ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/include/pybind11 ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/pybind11
   DEPENDEES install
 )
 
@@ -33,26 +34,7 @@ install(
   DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
-
-# We glob the entire _original_ pybind11 cmake directory since there would be a few
-# files in the devel-share directory which we do *not* want to copy as they will be
-# regenerated in the install space:
-#  - pybind11_catkin.cmake
-#  - pybind11_catkinConfig-version.cmake
-#  - pybind11_catkinConfig.cmake
-# file(GLOB PYBIND11_CMAKE_FILES ${PROJECT_BINARY_DIR}/install/share/cmake/pybind11/*.cmake)
-
-set(PYBIND11_CMAKE_FILES
-  ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/FindPythonLibsNew.cmake
-  ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/pybind11Config.cmake
-  ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/pybind11ConfigVersion.cmake
-  ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/pybind11NewTools.cmake
-  ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/pybind11Targets.cmake
-  ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/pybind11Common.cmake
-  ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/pybind11Tools.cmake
-)
-
 install(
-  FILES ${PYBIND11_CMAKE_FILES}
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake
+  DIRECTORY ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
The latest release causes build issues in MoveIt again:
https://build.ros.org/view/Nbin_uF64/job/Nbin_uF64__moveit_core__ubuntu_focal_amd64__binary/76/consoleFull
```
19:40:05 CMake Error in CMakeLists.txt:
19:40:05   Imported target "pybind11::module" includes non-existent path
19:40:05 
19:40:05     "/tmp/binarydeb/ros-noetic-pybind11-catkin-2.10.3/.obj-x86_64-linux-gnu/devel/include/pybind11_catkin"
```
Obviously, the devel-space include path was hard-coded into the installed cmake files.

This first set of commits improves the GHA config to reveal this issue.
I will immediately add another commit to fix it.