### PR TITLE
Use system pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ project(pybind11_catkin)
 
 find_package(catkin REQUIRED)
 
-find_package(pybind11 2.5.0 QUIET)
+set(PYBIND11_MINIMUM_REQUIRED_VERSION 2.5.0)
+
+find_package(pybind11 ${PYBIND11_MINIMUM_REQUIRED_VERSION} QUIET)
 if(NOT pybind11_FOUND)
   include(ExternalProject)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,27 +2,31 @@ cmake_minimum_required(VERSION 3.4)
 project(pybind11_catkin)
 
 find_package(catkin REQUIRED)
-include(ExternalProject)
 
-ExternalProject_Add(pybind11_src
-  URL "https://github.com/pybind/pybind11/archive/v2.10.3.zip"
-  UPDATE_COMMAND ""
-  CMAKE_ARGS -DPYBIND11_NOPYTHON=TRUE
-             -DPYBIND11_TEST=OFF
-             -DPYBIND11_INSTALL=ON
-             -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/install
-  # Workaround if DESTDIR is set
-  # See https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
-  INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR= install
-)
+find_package(pybind11 2.5.0 QUIET)
+if(NOT pybind11_FOUND)
+  include(ExternalProject)
 
-# Copy cmake/pybind11 and include/pybind11 to corresponding devel space folders
-ExternalProject_Add_Step(pybind11_src CopyToDevel
-  COMMENT "Copying to devel"
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/share/cmake/pybind11 ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/include/pybind11 ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/pybind11
-  DEPENDEES install
-)
+  ExternalProject_Add(pybind11_src
+    URL "https://github.com/pybind/pybind11/archive/v2.10.3.zip"
+    UPDATE_COMMAND ""
+    CMAKE_ARGS -DPYBIND11_NOPYTHON=TRUE
+              -DPYBIND11_TEST=OFF
+              -DPYBIND11_INSTALL=ON
+              -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/install
+    # Workaround if DESTDIR is set
+    # See https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
+    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR= install
+  )
+
+  # Copy cmake/pybind11 and include/pybind11 to corresponding devel space folders
+  ExternalProject_Add_Step(pybind11_src CopyToDevel
+    COMMENT "Copying to devel"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/share/cmake/pybind11 ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/include/pybind11 ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/pybind11
+    DEPENDEES install
+  )
+endif()
 
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})
 catkin_package(

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -4,13 +4,17 @@ cmake_minimum_required(VERSION 3.4)
 # To be able to configure, we need to set CMP0069 (interprocedural optimization) to NEW
 # cmake_policy(SET CMP0069 NEW)
 
-# Configure pybind11 using the cmake file provided by the upstream package.
-# This finds python includes and libs and defines pybind11_add_module()
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
-include(pybind11Config)
-include(pybind11Common)
-include(pybind11Tools)
+find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ QUIET)
+
+if(NOT pybind11_FOUND)
+    # Configure pybind11 using the cmake file provided by the upstream package.
+    # This finds python includes and libs and defines pybind11_add_module()
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+    set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
+    include(pybind11Config)
+    include(pybind11Common)
+    include(pybind11Tools)
+endif()
 
 # set variables used by pybind11_add_module()
 if(@INSTALLSPACE@)
@@ -22,5 +26,8 @@ list(APPEND pybind11_catkin_INCLUDE_DIRS "${PYTHON_INCLUDE_DIRS}")
 macro(pybind_add_module target_name other)
     pybind11_add_module(${ARGV})
     target_link_libraries(${target_name} PRIVATE ${PYTHON_LIBRARIES} ${catkin_LIBRARIES})
+    if (pybind11_FOUND)
+        target_link_libraries(${target_name} PRIVATE pybind11::module)
+    endif()
     set_target_properties(${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION})
 endmacro(pybind_add_module)

--- a/package.xml
+++ b/package.xml
@@ -16,4 +16,6 @@
   <build_export_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</build_export_depend>
   <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3</build_export_depend>
   <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</build_export_depend>
+  
+  <depend condition="($ROS_DISTRO != melodic) and ($ROS_DISTRO != noetic)">pybind11-dev</depend>
 </package>


### PR DESCRIPTION
continuing on the discussion in https://github.com/ros-planning/moveit/pull/3334 this modifies `pybind11_catkin` to be a thin wrapper around the system `pybind11` if it is at least version 2.5.0

I'm not 100% sure if the conditionals are actually necessary or if keeping a `ros-o` branch would be preferable due to being simpler