### PR TITLE
Fix some issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ if(NOT pybind11_FOUND)
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/include/pybind11 ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/pybind11
     DEPENDEES install
   )
+else()
+  message(STATUS "Found pybind11 ${pybind11_VERSION}: ${pybind11_DIR}")
 endif()
 
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.12)
 project(pybind11_catkin)
 
 find_package(catkin REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,18 @@ catkin_package(
 set(PYBIND11_MINIMUM_REQUIRED_VERSION 2.5.0)
 set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
 
-find_package(pybind11 ${PYBIND11_MINIMUM_REQUIRED_VERSION} QUIET)
+# Avoid finding pybind11 in parent catkin workspaces
+# To this end, remove paths in CATKIN_WORKSPACES from CMAKE_PREFIX_PATH
+foreach (_path ${CATKIN_WORKSPACES})
+  list(FIND CMAKE_PREFIX_PATH ${_path} _index)
+  if (${_index} GREATER -1)
+    list(REMOVE_AT CMAKE_PREFIX_PATH ${_index})
+  endif()
+endforeach()
+
+find_package(pybind11 ${PYBIND11_MINIMUM_REQUIRED_VERSION} QUIET
+  NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH)
+
 if(NOT pybind11_FOUND)
   include(ExternalProject)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ project(pybind11_catkin)
 
 find_package(catkin REQUIRED)
 
+catkin_package(
+  CFG_EXTRAS pybind11_catkin.cmake
+)
+
 set(PYBIND11_MINIMUM_REQUIRED_VERSION 2.5.0)
 set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
 
@@ -10,40 +14,33 @@ find_package(pybind11 ${PYBIND11_MINIMUM_REQUIRED_VERSION} QUIET)
 if(NOT pybind11_FOUND)
   include(ExternalProject)
 
+  set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/pybind11_src-install")
   ExternalProject_Add(pybind11_src
     URL "https://github.com/pybind/pybind11/archive/v2.10.3.zip"
-    UPDATE_COMMAND ""
+    UPDATE_DISCONNECTED TRUE
+    INSTALL_DIR ${INSTALL_DIR}
     CMAKE_ARGS -DPYBIND11_NOPYTHON=TRUE
-              -DPYBIND11_TEST=OFF
-              -DPYBIND11_INSTALL=ON
-              -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/install
-    # Workaround if DESTDIR is set
-    # See https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
-    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR= install
+               -DPYBIND11_TEST=OFF
+               -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+               -DCMAKE_INSTALL_INCLUDEDIR=include/${PROJECT_NAME}
+               -DPYBIND11_INTERNALS_VERSION=6
   )
-
   # Copy cmake/pybind11 and include/pybind11 to corresponding devel space folders
   ExternalProject_Add_Step(pybind11_src CopyToDevel
-    COMMENT "Copying to devel"
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/share/cmake/pybind11 ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/include/pybind11 ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/pybind11
+    COMMENT "Copying to devel space"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${INSTALL_DIR}/include/${PROJECT_NAME} ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${INSTALL_DIR}/share/cmake/pybind11 ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
     DEPENDEES install
+  )
+  # Install to install space
+  install(
+    DIRECTORY ${INSTALL_DIR}/include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  )
+  install(
+    DIRECTORY ${INSTALL_DIR}/share/cmake/pybind11/
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake
   )
 else()
   message(STATUS "Found pybind11 ${pybind11_VERSION}: ${pybind11_DIR}")
 endif()
-
-file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})
-catkin_package(
-  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}
-  CFG_EXTRAS pybind11_catkin.cmake
-)
-
-install(
-  DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-install(
-  DIRECTORY ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
-
-# As of July 31, 2020 pybind11 upgraded to CMake version 3.8 (effectively dropping 16.04).
-# To be able to configure, we need to set CMP0069 (interprocedural optimization) to NEW
-# cmake_policy(SET CMP0069 NEW)
+cmake_minimum_required(VERSION 3.12)
 
 find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ QUIET)
 

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
-find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@)
+find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ REQUIRED)
 
 
 # Augment the pybind11_add_module function to set the output directory

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -4,6 +4,7 @@ set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
 find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ REQUIRED)
 
 list(APPEND @PROJECT_NAME@_LIBRARIES pybind11::pybind11)
+list(APPEND @PROJECT_NAME@_INCLUDE_DIRS ${pybind11_INCLUDE_DIRS})
 
 # Augment the pybind11_add_module function to set the output directory
 macro(pybind_add_module target_name)

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
+find_package(Python COMPONENTS Interpreter Development)
 find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ QUIET)
 
 if(NOT pybind11_FOUND)
@@ -17,7 +18,7 @@ if(@INSTALLSPACE@)
   set(pybind11_catkin_INCLUDE_DIRS "${pybind11_catkin_INCLUDE_DIRS}/@PROJECT_NAME@")
 endif()
 set(PYBIND11_INCLUDE_DIR "${pybind11_catkin_INCLUDE_DIRS}")
-list(APPEND pybind11_catkin_INCLUDE_DIRS "${PYTHON_INCLUDE_DIRS}")
+list(APPEND pybind11_catkin_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
 
 macro(pybind_add_module target_name other)
     pybind11_add_module(${ARGV})

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -1,30 +1,11 @@
 cmake_minimum_required(VERSION 3.12)
 
-find_package(Python COMPONENTS Interpreter Development)
-find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ QUIET)
+set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
+find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@)
 
-if(NOT pybind11_FOUND)
-    # Configure pybind11 using the cmake file provided by the upstream package.
-    # This finds python includes and libs and defines pybind11_add_module()
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-    set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
-    include(pybind11Config)
-    include(pybind11Common)
-    include(pybind11Tools)
-endif()
 
-# set variables used by pybind11_add_module()
-if(@INSTALLSPACE@)
-  set(pybind11_catkin_INCLUDE_DIRS "${pybind11_catkin_INCLUDE_DIRS}/@PROJECT_NAME@")
-endif()
-set(PYBIND11_INCLUDE_DIR "${pybind11_catkin_INCLUDE_DIRS}")
-list(APPEND pybind11_catkin_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
-
-macro(pybind_add_module target_name other)
+# Augment the pybind11_add_module function to set the output directory
+macro(pybind_add_module target_name)
     pybind11_add_module(${ARGV})
-    target_link_libraries(${target_name} PRIVATE ${PYTHON_LIBRARIES} ${catkin_LIBRARIES})
-    if (pybind11_FOUND)
-        target_link_libraries(${target_name} PRIVATE pybind11::module)
-    endif()
     set_target_properties(${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION})
 endmacro(pybind_add_module)

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
 find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ REQUIRED)
 
+list(APPEND @PROJECT_NAME@_LIBRARIES pybind11::pybind11)
 
 # Augment the pybind11_add_module function to set the output directory
 macro(pybind_add_module target_name)

--- a/package.xml
+++ b/package.xml
@@ -6,16 +6,17 @@
   <maintainer email="wolfgang@robots.ox.ac.uk">Wolfgang Merkt</maintainer>
   <author>Wolfgang Merkt</author>
   <author>Vladimir Ivan</author>
+  <author>Robert Haschke</author>
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_export_depend>eigen</build_export_depend>
 
-  <build_export_depend condition="$ROS_PYTHON_VERSION == 2">python</build_export_depend>
+  <build_export_depend condition="$ROS_PYTHON_VERSION == 2">python-dev</build_export_depend>
   <build_export_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</build_export_depend>
-  <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3</build_export_depend>
+  <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-dev</build_export_depend>
   <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</build_export_depend>
-  
+
   <depend condition="($ROS_DISTRO != melodic) and ($ROS_DISTRO != noetic)">pybind11-dev</depend>
 </package>


### PR DESCRIPTION
This fixes several issues, I recently ran into:
- Modern FindPython module (since cmake 3.12) uses a different _INCLUDE_DIRS_ variable
- `Python.h` was not found
- pybind11 was used from parent catkin workspaces
- Simplify cmake files