### PR TITLE
[WIP] Bump to version 3.0.0 and PYBIND11_INTERNALS_VERSION=7

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -12,6 +12,7 @@ jobs:
       ROS_DISTRO: ${{ matrix.distro }}
       DOWNSTREAM_WORKSPACE: github:arturmiller/pybind11_examples#master
       BEFORE_SETUP_DOWNSTREAM_WORKSPACE: ${{ matrix.builder != 'catkin_make_isolated_devel' && 'rm -rf $HOME/target_ws/devel' || '' }}
+      BEFORE_BUILD_TARGET_WORKSPACE: ici_apt_install git-core
 
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(pybind11_catkin)
 
 find_package(catkin REQUIRED)
 
-set(PYBIND11_MINIMUM_REQUIRED_VERSION 2.5.0)
+# Ensure PYBIND11_INTERNALS_VERSION >= 6
+set(PYBIND11_MINIMUM_REQUIRED_VERSION 2.13.1)
 set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
 
 find_package(pybind11 ${PYBIND11_MINIMUM_REQUIRED_VERSION} QUIET)
@@ -11,12 +12,13 @@ if(NOT pybind11_FOUND)
   include(ExternalProject)
 
   ExternalProject_Add(pybind11_src
-    URL "https://github.com/pybind/pybind11/archive/v2.10.3.zip"
+    URL "https://github.com/pybind/pybind11/archive/v2.13.6.zip"
     UPDATE_COMMAND ""
     CMAKE_ARGS -DPYBIND11_NOPYTHON=TRUE
               -DPYBIND11_TEST=OFF
               -DPYBIND11_INSTALL=ON
               -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/install
+              -DPYBIND11_INTERNALS_VERSION=6
     # Workaround if DESTDIR is set
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR= install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(pybind11_catkin)
 
 find_package(catkin REQUIRED)
 
-# Ensure PYBIND11_INTERNALS_VERSION >= 6
-set(PYBIND11_MINIMUM_REQUIRED_VERSION 2.13.1)
+# Ensure PYBIND11_INTERNALS_VERSION >= 7
+set(PYBIND11_MINIMUM_REQUIRED_VERSION 3.0.0)
 set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
 
 find_package(pybind11 ${PYBIND11_MINIMUM_REQUIRED_VERSION} QUIET)
@@ -12,13 +12,14 @@ if(NOT pybind11_FOUND)
   include(ExternalProject)
 
   ExternalProject_Add(pybind11_src
-    URL "https://github.com/pybind/pybind11/archive/v2.13.6.zip"
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG d8565ac7317b4838a08308170f5b9ba82d091546
     UPDATE_COMMAND ""
     CMAKE_ARGS -DPYBIND11_NOPYTHON=TRUE
               -DPYBIND11_TEST=OFF
               -DPYBIND11_INSTALL=ON
               -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/install
-              -DPYBIND11_INTERNALS_VERSION=6
+              -DPYBIND11_INTERNALS_VERSION=7
     # Workaround if DESTDIR is set
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR= install

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,4 @@
   <build_export_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</build_export_depend>
   <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3</build_export_depend>
   <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</build_export_depend>
-  
-  <depend condition="($ROS_DISTRO != melodic) and ($ROS_DISTRO != noetic)">pybind11-dev</depend>
 </package>


### PR DESCRIPTION
Update to the latest release that is compatible with `smart_holder` branch. 
This breaks ABI with existing modules that were using PYBIND11_INTERNALS_VERSION=4.
See https://github.com/pybind/pybind11/discussions/5524 for details.